### PR TITLE
fix: write plan output to file to avoid ARG_MAX exceeded

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -113,7 +113,7 @@ runs:
       set +e
       cd ${{ inputs.directory }} && \
       terraform plan -input=false -no-color -out=tfplan ${{ inputs.ARGS }}
-      terraform show -no-color tfplan
+      terraform show -no-color tfplan > plan_raw.txt 2>&1
     shell: bash
 
   - name: verify terraform plan
@@ -125,12 +125,9 @@ runs:
 
   - id: plan_output
     if: inputs.ACTION == 'plan'
-    env:
-      PLAN_OUTPUT: ${{ steps.plan.outputs.stdout || steps.plan.outputs.stderr }}
     run: |
       echo -e '## ${{ inputs.DIRECTORY }} plan\n' > ${{ inputs.DIRECTORY }}/plan.txt
-      printf '%s' "$PLAN_OUTPUT" \
-      | sed -E 's/^([[:space:]]+)([-+])/\2\1/g' >> ${{ inputs.DIRECTORY }}/plan.txt
+      sed -E 's/^([[:space:]]+)([-+])/\2\1/g' ${{ inputs.DIRECTORY }}/plan_raw.txt >> ${{ inputs.DIRECTORY }}/plan.txt
       maxsize=65000
       actualsize=$(wc -c < ${{ inputs.DIRECTORY }}/plan.txt)
       if [ $actualsize -gt $maxsize ]; then


### PR DESCRIPTION
## Problem

When `terraform show` output is large (e.g. events-prod/ecs with a 550-line tfvars), capturing it via `outputs.stdout` and injecting it into a subsequent step as env var `PLAN_OUTPUT` exceeds Linux's `ARG_MAX` (~2MB combined env+args). This causes:

```
Error: An error occurred trying to start process '/usr/bin/bash' with working directory '...'. Argument list too long
```

## Fix

- In the `plan` step: redirect `terraform show` output to `plan_raw.txt` instead of stdout
- In the `plan_output` step: remove the `PLAN_OUTPUT` env var and read directly from `plan_raw.txt` with `sed`

No functional change to the plan comment output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)